### PR TITLE
Update ChangeLog and Contributors

### DIFF
--- a/Docs/Users/ChangeLog.txt
+++ b/Docs/Users/ChangeLog.txt
@@ -4,6 +4,24 @@ to Subversion revision numbers (rXXXXX).
 
 For changes in version 1.1 beta 1 and earlier, see the History.txt file.
 
+Frhed 0.10904.2017.11 (2022-11-6)
+  Add Open files larger than 2GB for 64bit version
+
+frhed 0.10904.2017.9 (2022-03-18)
+  Add Tranlslation : Polish, Slovak
+
+Frhed 0.10904.2017.7 (2021-04-03)
+  Add ARM64 support
+
+Frhed 0.10904.2017.1 (2019-08-25)
+  (Major changes in first release on GitHub)
+  Add Implement undo & redo
+  Improve Tweak icon for high DPI (by Tim Gerundt @gerundt)
+  Remove Win9x support
+  Add Tranlslation : Galician, Slovenian
+
+Moved to GitHub via bitbucket.org
+
 Frhed 0.10902.2013 experimental
   Auto-elevate the application for CMD_OpenDrive()
 

--- a/Docs/Users/Contributors.txt
+++ b/Docs/Users/Contributors.txt
@@ -4,8 +4,9 @@ People who have contributed to Frhed
 Original developer:
 Raihan Kibria <raihan@kibria.de>
 
-Maintainer of this version:
-Jochen Neubeck
+Maintainer on GitHub:
+Takashi Sawanaka (GitHub@sdottaka, 2014 and after)
+And other contributors: https://github.com/WinMerge/frhed/graphs/contributors
 
 Localization:
 
@@ -16,14 +17,17 @@ Localization:
   Frédéric Dectot
 
 * Galician
-  Luis A. Martínez <luis.martinez.sobrino at gmail.com>
+  Luis A. Martínez <luis.martinez.sobrino at gmail.com> (GitHub@qosobrin)
 
 * German
   Tim Gerundt <gerundt@users.sourceforge.net>
-  Mr-Update
+  Mr-Update (GitHub@Mr-Update)
 
 * Japanese
   Takashi Sawanaka
+
+* Polish
+  Mirosław Żylewicz (GitHub@miroslaw-zylewicz)
 
 * Slovak
   Jozef Matta <jozef.m923@gmail.com>
@@ -32,6 +36,8 @@ Localization:
   Jadran Rudec <jrudec at gmail.com>
 
 Other contributors (heksedit versions):
+Jochen Tucht (@jtuc in history, 2017)
+Jochen Neubeck (admin@jochen in history, 2013)
 Kimmo Varis <kimmov@winmerge.org>
 Tim Gerundt <gerundt@users.sourceforge.net>
 Martin Hughes <martinhughes@users.sourceforge.net>


### PR DESCRIPTION
There were many forks and it was difficult to find the latest Frhed. So, I made a brief update to the ChangeLog.

Notice: Frhed at PortableApps.com has been updated to the version here GitHub.
* [Latest Frhed is in the WinMerge](https://portableapps.com/node/67437) (PortableApps.com)

Suggestions for Japanese translation:
こんにちは！私の意見になりますが、「する」の有無に一貫性がないのですが、ない方が短いのでいいと思います。
* 末尾の「する」の除去
* 「検索する文字列」の「する」の除去。
